### PR TITLE
Require AppleClang builds to be successful

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,12 +112,10 @@ jobs:
       id: build
       working-directory: ${{ runner.workspace }}/build
       run: cmake --build . --config ${{ matrix.build_type }} -j3
-      continue-on-error: true # Latest AppleClang version appears to be too old.
 
     - name: Run Tests
       working-directory: ${{ runner.workspace }}/build
       run: ctest -C ${{ matrix.build_type }} -VV
-      continue-on-error: ${{ steps.build.outcome != 'success' }}
 
   build-dds:
     runs-on: ubuntu-20.04


### PR DESCRIPTION
AppleClang has had updates to newer versions, which should include more C++20 features. It may now be able to compile TerseLambda.

Fixes #5 , at least if AppleClang's updates actually do include the necessary C++20 features.