### PR TITLE
Parenthesize expressions

### DIFF
--- a/include/tl/tl.hpp
+++ b/include/tl/tl.hpp
@@ -38,7 +38,7 @@ Distributed under the MIT License
         [[maybe_unused]] auto&& _3 = ::tl_detail::nth<2>(TL_FWD(_args)...);                        \
         [[maybe_unused]] auto&& _4 = ::tl_detail::nth<3>(TL_FWD(_args)...);                        \
                                                                                                    \
-        return __VA_ARGS__;                                                                        \
+        return (__VA_ARGS__);                                                                      \
     }
 
 #define TL_DETAIL_REQUIRES(NOEXCEPT, ...)                                                          \


### PR DESCRIPTION
`decltype(auto)` is a funny thing. Or rather, `decltype(<expr>)` is a funny thing. For one particular kind of expression, it behaves differently than may be expected:

```c++
struct some_type {
  std::string data_member;
};
some_type something = ...;
static_assert(std::is_same_v<decltype(std::as_const(something).data_member), std::string>);
static_assert(std::is_same_v<decltype(std::move(something).data_member), std::string>);
```

In short, it's giving the type of `data_member`, even though `something` is not a prvalue.

But we can regain the "expected" behavior by parenthesizing the `<expr>`&mdash;`decltype((<expr>))`&mdash;because that changes the kind of expression:

```c++
static_assert(std::is_same_v<decltype((std::as_const(something).data_member)), const std::string&>);
static_assert(std::is_same_v<decltype((std::move(something).data_member)), std::string&&>);
```

`decltype(auto)` works the same way if you replace the `auto` with the `<expr>` in `return <expr>`, i.e. if we parenthesize the return value, we get `decltype((<expr>))` behavior.

---

The interesting question is: does this break anything? Without carefully thinking it through, it's not particularly obvious what happens when `<expr>` is a prvalue, e.g. `42`. `decltype(42)` is `int`, and we'd better hope `decltype((42))` is `int`, not `int&&`. It turns out that this works well; `decltype((<prvalue>))` is the same type as `decltype(<prvalue>)`.

I previously ran into some issues with compilers (probably GCC) getting confused on this point, but it seems to work now.

---

The change: make `TLR` `return (__VA_ARGS__);` rather than unparenthesized. This removes a copy when returning data members, but more importantly, it gives the value category that better aligns with how I believe the terse lambda should behave. `TL` for value data members or explicit casts for exotic member types (e.g. references) allow retaining the old behavior.