### PR TITLE
Fix target branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 jobs:
   build-linux:


### PR DESCRIPTION
The main target branch for TerseLambda has been changed to "main", but ci.yml was still referencing "master". This is a likely reason for the CI no longer working.